### PR TITLE
Fix storage cleanup for compressed entries

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -892,8 +892,10 @@ class StorageManager {
       const keyData = [];
       for (const key of keys) {
         try {
-          const data = JSON.parse(localStorage.getItem(key));
-          keyData.push({ key, timestamp: data.timestamp || 0 });
+          const rawData = localStorage.getItem(key);
+          const decompressed = this.decompressData(rawData);
+          const data = decompressed ? JSON.parse(decompressed) : null;
+          keyData.push({ key, timestamp: data?.timestamp || 0 });
         } catch (error) {
           // Invalid data, mark for removal
           keyData.push({ key, timestamp: 0 });


### PR DESCRIPTION
## Summary
- handle compressed conversation data during storage cleanup to avoid JSON parsing failures and preserve timestamps

## Testing
- `node --check src/content.js`

------
https://chatgpt.com/codex/tasks/task_e_68a77b611c088320939cbdd50ac58380